### PR TITLE
ci: GitHub Actions for typecheck/lint/format/test/build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+# Cancel in-progress runs for the same PR to save CI minutes.
+# Master pushes still run to completion (no cancel).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: typecheck / lint / format / test / build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Phase 4 of 8 in the agentic modernization plan.

## What changed

- New `.github/workflows/ci.yml`. Runs on `pull_request` to `master` and `push` to `master`.
- Single Ubuntu job, sequential steps:
  1. `actions/checkout@v4`
  2. `actions/setup-node@v4` with `node-version-file: '.nvmrc'` (= 20.19) and `cache: 'npm'`
  3. `npm ci`
  4. `npm run typecheck`
  5. `npm run lint`
  6. `npm run format:check`
  7. `npm test` (19 tests via Vitest 3 + jsdom)
  8. `npm run build` (Vite 5 + `tsc --noEmit`)
- Concurrency: cancel in-progress runs on new PR pushes; master pushes never cancel.
- Permissions: `contents: read` only.

## Out of scope

- Coverage gate / threshold — Phase 5 (E2E + a11y).
- Deploy preview / gh-pages — Phase 8 (polish + Lighthouse).
- Branch protection rules — these are repo settings, not in-repo config; recommend turning on "Require status check 'CI' to pass before merge" manually in GitHub UI after this lands.
- Lighthouse CI — Phase 8.
- Test matrix across Node versions — engine is pinned to >= 20.19 < 21, so one Node version is correct.

## Verification

Simulated locally before pushing:

- `npm ci` ✅
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm test` ✅ (19 passing)
- `npm run build` ✅

After this PR opens, the workflow will run against itself and should turn green within ~2 minutes.