### PR TITLE
feat: E2E (Playwright) + a11y (axe-core) gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,46 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  e2e:
+    name: e2e + a11y (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Build app
+        run: npm run build
+
+      - name: Run E2E + a11y
+        run: npm run test:e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,6 @@ jobs:
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
-      - name: Build app
-        run: npm run build
-
       - name: Run E2E + a11y
         run: npm run test:e2e
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 
 # testing
 /coverage
+playwright-report/
+test-results/
+playwright/.cache/
 
 # production
 /build

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@eslint/js": "^9.9.0",
+        "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -108,6 +110,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1283,6 +1298,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -5669,6 +5700,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,11 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "pretest:e2e": "npm run build",
     "test:e2e": "playwright test",
+    "pretest:e2e:ui": "npm run build",
     "test:e2e:ui": "playwright test --ui",
+    "pretest:e2e:headed": "npm run build",
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,14 +16,19 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@eslint/js": "^9.9.0",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const PORT = 4173
+const BASE_URL = `http://127.0.0.1:${PORT}`
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: `npm run preview -- --host 127.0.0.1 --port ${PORT} --strictPort`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+})

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -7,6 +7,6 @@
 .title {
   margin: 1rem 0 1.5rem;
   text-align: center;
-  color: #4caf50;
+  color: #2e7d32;
   font-weight: 400;
 }

--- a/src/components/AddTarefa.module.css
+++ b/src/components/AddTarefa.module.css
@@ -22,6 +22,6 @@
 }
 
 .input:focus {
-  border-bottom-color: #4caf50;
-  box-shadow: 0 1px 0 0 #4caf50;
+  border-bottom-color: #2e7d32;
+  box-shadow: 0 1px 0 0 #2e7d32;
 }

--- a/src/components/Footer.module.css
+++ b/src/components/Footer.module.css
@@ -7,8 +7,8 @@
 }
 
 .wrapper a {
-  color: #4caf50;
-  text-decoration: none;
+  color: #2e7d32;
+  text-decoration: underline;
 }
 
 .wrapper a:hover,

--- a/src/components/Tarefas.module.css
+++ b/src/components/Tarefas.module.css
@@ -67,7 +67,7 @@
 }
 
 .itemButton:focus-visible {
-  outline: 2px solid #4caf50;
+  outline: 2px solid #2e7d32;
   outline-offset: -2px;
 }
 

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+
+const BLOCKING_IMPACTS = ['serious', 'critical'] as const
+type BlockingImpact = (typeof BLOCKING_IMPACTS)[number]
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/')
+  await page.evaluate(() => window.localStorage.clear())
+  await page.reload()
+})
+
+test('no serious or critical violations on the initial render', async ({ page }) => {
+  const { violations } = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze()
+
+  const blocking = violations.filter((v) => BLOCKING_IMPACTS.includes(v.impact as BlockingImpact))
+
+  expect(blocking, JSON.stringify(blocking, null, 2)).toEqual([])
+})
+
+test('no serious or critical violations after adding several tarefas', async ({ page }) => {
+  const input = page.getByLabel(/escreva abaixo uma tarefa/i)
+  for (const text of ['One', 'Two', 'Three']) {
+    await input.fill(text)
+    await input.press('Enter')
+  }
+
+  const { violations } = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze()
+
+  const blocking = violations.filter((v) => BLOCKING_IMPACTS.includes(v.impact as BlockingImpact))
+
+  expect(blocking, JSON.stringify(blocking, null, 2)).toEqual([])
+})

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test'
+
+const STORAGE_KEY = 'lista-de-tarefas:v1:tarefas'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/')
+  await page.evaluate(() => window.localStorage.clear())
+  await page.reload()
+})
+
+test('seeds render on a fresh load', async ({ page }) => {
+  await expect(page.getByRole('button', { name: 'Excluir tarefa: Tarefa exemplo 1' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Excluir tarefa: Tarefa exemplo 2' })).toBeVisible()
+})
+
+test('adds a tarefa via Enter and clears the input', async ({ page }) => {
+  const input = page.getByLabel(/escreva abaixo uma tarefa/i)
+  await input.fill('Test E2E task')
+  await input.press('Enter')
+
+  await expect(page.getByRole('button', { name: 'Excluir tarefa: Test E2E task' })).toBeVisible()
+  await expect(input).toHaveValue('')
+})
+
+test('clicking a tarefa removes it after the animation delay', async ({ page }) => {
+  const target = page.getByRole('button', { name: 'Excluir tarefa: Tarefa exemplo 1' })
+  await target.click()
+  await expect(target).toHaveCount(0, { timeout: 2_000 })
+  await expect(page.getByRole('button', { name: 'Excluir tarefa: Tarefa exemplo 2' })).toBeVisible()
+})
+
+test('state persists across a full reload', async ({ page }) => {
+  const input = page.getByLabel(/escreva abaixo uma tarefa/i)
+  await input.fill('Persisted')
+  await input.press('Enter')
+
+  await page.reload()
+
+  await expect(page.getByRole('button', { name: 'Excluir tarefa: Persisted' })).toBeVisible()
+})
+
+test('writes state under the versioned storage key', async ({ page }) => {
+  const stored = await page.evaluate((k) => window.localStorage.getItem(k), STORAGE_KEY)
+  expect(stored).not.toBeNull()
+  expect(stored).toContain('Tarefa exemplo 1')
+})
+
+test('empty list state shows when everything is removed', async ({ page }) => {
+  // remove both seeds
+  await page.getByRole('button', { name: 'Excluir tarefa: Tarefa exemplo 1' }).click()
+  await expect(page.getByRole('button', { name: 'Excluir tarefa: Tarefa exemplo 1' })).toHaveCount(
+    0,
+    { timeout: 2_000 },
+  )
+  await page.getByRole('button', { name: 'Excluir tarefa: Tarefa exemplo 2' }).click()
+  await expect(page.getByText('Não há tarefas ainda.')).toBeVisible()
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "allowSyntheticDefaultImports": true,
     "types": ["@testing-library/jest-dom"]
   },
-  "include": ["src"],
+  "include": ["src", "tests"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -8,5 +8,5 @@
     "strict": true,
     "types": ["node"]
   },
-  "include": ["vite.config.ts", "vitest.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts", "playwright.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     css: true,
+    exclude: ['**/node_modules/**', '**/dist/**', 'tests/e2e/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],


### PR DESCRIPTION
Phase 5 of 8 in the agentic modernization plan.

## What changed

### Tooling

- **`@playwright/test`** + **`@axe-core/playwright`** added as dev deps.
- Chromium-only browser install (`npx playwright install --with-deps chromium`). Firefox/WebKit deliberately out of scope.
- New `playwright.config.ts` at repo root. `webServer` runs `vite preview` so tests hit the production build, not the dev server. `--host 127.0.0.1` is passed so the preview binds to the same interface Playwright probes for readiness.

### Scripts

- `npm run test:e2e` — headless full run
- `npm run test:e2e:ui` — interactive UI mode
- `npm run test:e2e:headed` — visible browser

### Tests

- **`tests/e2e/smoke.spec.ts`** — 6 tests covering: seed render, Enter-to-add, click-to-delete (with animation delay), reload persistence, versioned storage key, empty state.
- **`tests/e2e/a11y.spec.ts`** — 2 tests asserting zero serious/critical axe violations (wcag2a + wcag2aa) on initial render and after adding several items.

### CI

- New `e2e` job in `.github/workflows/ci.yml`, parallel to the existing `ci` job. Caches the Playwright browser bundle by package-lock hash. Uploads the Playwright HTML report on failure.

### A11y fixes (caught by the new gate on first run)

The first a11y run flagged two pre-existing serious WCAG violations in the portfolio styles. Fixed in this PR so the gate ships green:

- **`color-contrast` (serious, WCAG 2 AA)** — the brand green `#4caf50` on white was 2.77:1 (h1 title and footer link). Darkened to `#2e7d32` (~5.1:1 on white) across `App.module.css`, `AddTarefa.module.css`, `Footer.module.css`, `Tarefas.module.css` to keep brand consistency in focus indicators too.
- **`link-in-text-block` (serious, WCAG 2 A)** — the footer GitHub link had `text-decoration: none` at rest. Set to `underline` at rest (hover/focus styles unchanged).

### Misc

- `tsconfig.json` include extended to `tests` so the typecheck covers E2E files.
- `vitest.config.ts` excludes `tests/e2e/**` so vitest does not try to load Playwright specs.
- `playwright-report/`, `test-results/`, `playwright/.cache/` added to `.gitignore`.

## Verification

Local (Codespace):

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm test` ✅ (19 unit tests)
- `npm run build` ✅
- `npm run test:e2e` ✅ (8 e2e/a11y tests, chromium)

## Out of scope

- Mobile viewport coverage — defer until we have a mobile-specific use case.
- Firefox / WebKit — Chromium-only for now; broader matrix in a future phase if portfolio audience needs it.
- Visual regression / screenshot diffing — not in the plan.
- Coverage threshold for unit tests — would belong in Phase 6 or later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)