### PR TITLE
chore: auto-deploy to GitHub Pages via Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,61 @@
+name: Deploy
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Don't cancel an in-progress deploy when a new master commit arrives.
+# Last-write-wins for the queued one, but we don't want a half-published deploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build for Pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          DEPLOY_BASE: /lista-de-tarefas/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  base: process.env.DEPLOY_BASE ?? '/',
   server: {
     port: 5173,
   },


### PR DESCRIPTION
Infrastructure fix outside the numbered modernization phases. The site at https://paulo-raoni.github.io/lista-de-tarefas/ has been serving the original CRA-era code because there was no auto-deploy — `gh-pages` branch holds two ancient commits ("Create README.md", "Updates"), and Pages was configured in legacy branch-deploy mode. This PR adds the GitHub Actions deploy pipeline.

## What changed

- `vite.config.ts`: `base` is now `process.env.DEPLOY_BASE ?? '/'`. Local dev, preview, and the existing CI/e2e gates leave the var unset → base stays `/` and nothing changes for them. The deploy workflow sets `DEPLOY_BASE=/lista-de-tarefas/` for the production build so assets resolve under the Pages subpath.
- New `.github/workflows/deploy.yml`. Triggers on push to `master` (and manual `workflow_dispatch`). Two jobs:
  1. **build** — `npm ci`, then `npm run build` with `DEPLOY_BASE` set, then uploads `dist/` as a Pages artifact.
  2. **deploy** — needs build, runs `actions/deploy-pages@v4`. Concurrency: `pages` group, `cancel-in-progress: false` so a queued deploy doesn't interrupt an in-flight one.
- Permissions are scoped: `contents: read`, `pages: write`, `id-token: write` (OIDC for the deploy action's auth).

## Verification

Local (Codespace):

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm test` ✅
- `npm run build` (default base) ✅
- `DEPLOY_BASE=/lista-de-tarefas/ npm run build` then `grep` confirms asset URLs are prefixed under `/lista-de-tarefas/` ✅
- `npm run test:e2e` ✅ (no change — base stays `/` without DEPLOY_BASE)

The existing CI (`ci.yml`) is untouched and will keep passing.

## Post-merge steps (manual, one-time)

1. Switch the repo's Pages source from the legacy branch to GitHub Actions:

   ```
   gh api -X PUT repos/paulo-raoni/lista-de-tarefas/pages -f 'build_type=workflow'
   ```

   Or via the GitHub UI: Settings → Pages → Source → "GitHub Actions".

2. The first deploy fires automatically on the merge commit. Watch it:

   ```
   gh run watch
   ```

   When the deploy job goes green, the site updates to the current master.

3. (Optional) Delete the now-unused `gh-pages` branch:

   ```
   git push origin --delete gh-pages
   ```

## Brief downtime warning

Switching Pages settings before the new deploy workflow has run once will leave the site 404 for ~1–2 minutes. If you'd rather avoid that, merge this PR first — the deploy run will fail because settings are still legacy — then switch settings → re-run the failed workflow via `gh run rerun`. Either order works.

## Out of scope

- README rewrite / Lighthouse — Phase 8.
- Deleting `gh-pages` branch — optional, post-merge.
- Custom domain — not requested.