### PR TITLE
feat: phase 8 polish (README, manifest, meta, favicon, footer year, theme switcher)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,96 @@
-# Lista de Tarefas - Todo List
+# Lista de Tarefas
 
-> Projeto feito com Create React App - This project was bootstrapped with Create React App.
+> A todo list app that started in 2018 as a Create React App project and was modernized in 2026 with Vite, TypeScript, dark mode, i18n, and a full test suite.
 
-## Características do projeto (project features)
+[![CI](https://github.com/paulo-raoni/lista-de-tarefas/actions/workflows/ci.yml/badge.svg)](https://github.com/paulo-raoni/lista-de-tarefas/actions/workflows/ci.yml)
+[![Deploy](https://github.com/paulo-raoni/lista-de-tarefas/actions/workflows/deploy.yml/badge.svg)](https://github.com/paulo-raoni/lista-de-tarefas/actions/workflows/deploy.yml)
 
-- Uma aplicação simples para listar tarefas - simple todo list
-- Algumas animações CSS - some CSS animations
+**Live demo:** https://paulo-raoni.github.io/lista-de-tarefas/
 
-## Quickstart
+## Features
+
+- Add and remove todos with a smooth slide-out animation
+- Persistence via `localStorage` (versioned key, graceful degradation when disabled)
+- i18n with Portuguese (PT-BR) and English; language preference persisted
+- Light / dark / system theme; system mode reacts live to OS changes
+- WCAG AA contrast verified across both themes via axe-core in CI
+- Keyboard accessible: every interaction reachable by Tab, Enter, Space, Escape
+- Responsive layout
+
+## Tech stack
+
+- **Build:** Vite 5
+- **Framework:** React 18 with hooks
+- **Language:** TypeScript 5 (strict)
+- **Styling:** CSS Modules + CSS custom properties for theming
+- **i18n:** react-i18next
+- **Testing:**
+  - Vitest + React Testing Library (unit, jsdom)
+  - Playwright + @axe-core/playwright (e2e + a11y)
+- **CI/CD:** GitHub Actions (typecheck, lint, format, unit tests, build, e2e + a11y) and auto-deploy to GitHub Pages
+- **Tooling:** ESLint 9 (flat config) + Prettier
+
+## Local development
+
+Requires Node 20.19 or newer (see `.nvmrc`).
+
+```bash
+npm ci
+npm run dev          # http://localhost:5173
+```
+
+Other scripts:
+
+```bash
+npm run build           # production build
+npm run preview         # serve the production build locally
+npm run typecheck       # tsc --noEmit
+npm run lint            # eslint
+npm run format          # prettier write
+npm run format:check    # prettier check
+npm test                # unit tests (vitest)
+npm run test:watch      # unit tests in watch mode
+npm run test:coverage   # unit tests with v8 coverage
+npm run test:e2e        # playwright (builds first via pretest:e2e)
+```
+
+## Project structure
 
 ```
-npm install
-npm run dev        # http://localhost:5173
-npm run build
-npm run preview
-npm run typecheck
-npm run lint
+src/
+├── components/         # Functional components
+├── hooks/              # Reusable hooks (useTodos, useLocalStorage)
+├── i18n/               # react-i18next setup + translation catalogs
+├── theme/              # Theme storage + useTheme hook
+├── styles/global.css   # CSS variables for both themes
+├── test/setup.ts       # Vitest setup (jest-dom, cleanup, i18n + theme reset)
+├── App.tsx
+└── main.tsx
+tests/e2e/              # Playwright specs (smoke, a11y, i18n, theme)
+.github/workflows/      # CI + Deploy
+.nvmrc                  # Node 20.19
 ```
+
+## Modernization journey
+
+The 2026 modernization landed in 8 phases:
+
+1. **CRA → Vite + TypeScript strict** — drop CRA's webpack 4 toolchain, gain a fast dev server.
+2. **Functional + CSS Modules** — class components → hooks, drop styled-components and the Materialize CDN, fix the `deleteTarefa` reindexing bug, restore a11y.
+3. **Unit tests** — Vitest + React Testing Library covering hooks and components.
+4. **CI** — GitHub Actions running typecheck / lint / format / test / build on every PR.
+5. **E2E + a11y** — Playwright smoke tests + axe-core a11y gate, zero serious/critical violations.
+6. **i18n** — PT-BR + EN via react-i18next, accessible language switcher, persistence.
+7. **Dark mode** — light / dark / system themes via CSS custom properties, anti-flash inline script, WCAG-AA contrast.
+8. **Polish** — README, manifest, favicons, Open Graph + Twitter card meta, dynamic footer year.
+
+A future Phase 9 will rename Portuguese identifiers throughout the codebase (file names, types, variables, translation keys) to English, with a one-time localStorage migration to avoid losing existing users' saved tasks.
 
 ## License
 
-Copyright (c) 2018 by Paulo Raoni Costa Bezerra
+MIT.
+
+Copyright © 2018–2026 Paulo Raoni Costa Bezerra.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/index.html
+++ b/index.html
@@ -2,10 +2,23 @@
 <html lang="pt-BR">
   <head>
     <meta charset="utf-8" />
-    <link rel="shortcut icon" href="/checkList.ico" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="alternate icon" type="image/x-icon" href="/checkList.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="description" content="Lista de tarefas — Todo list app" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Lista de Tarefas" />
+    <meta property="og:description" content="Lista de tarefas — Todo list app" />
+    <meta property="og:url" content="https://paulo-raoni.github.io/lista-de-tarefas/" />
+    <meta property="og:locale" content="pt_BR" />
+    <meta property="og:locale:alternate" content="en_US" />
+
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Lista de Tarefas" />
+    <meta name="twitter:description" content="Lista de tarefas — Todo list app" />
+
     <link rel="manifest" href="/manifest.json" />
     <title>Lista de Tarefas App</title>
     <script>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <style>
+    :root { color: #2e7d32; }
+    @media (prefers-color-scheme: dark) {
+      :root { color: #66bb6a; }
+    }
+    path { stroke: currentColor; }
+  </style>
+  <path d="M9 11l3 3L22 4" />
+  <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,15 +1,23 @@
 {
   "short_name": "Tarefas",
   "name": "Lista de Tarefas",
+  "description": "Lista de tarefas — Todo list app",
   "icons": [
     {
-      "src": "favicon.ico",
+      "src": "checkList.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
+    },
+    {
+      "src": "favicon.svg",
+      "type": "image/svg+xml",
+      "purpose": "any"
     }
   ],
-  "start_url": ".",
+  "start_url": "./",
+  "scope": "./",
   "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "lang": "pt-BR"
 }

--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Footer from './Footer'
+
+describe('Footer', () => {
+  it('renders a copyright range from 2018 to the current year', () => {
+    render(<Footer />)
+    const text = screen.getByRole('contentinfo').textContent ?? ''
+    const currentYear = new Date().getFullYear().toString()
+    expect(text).toContain('2018')
+    expect(text).toContain(currentYear)
+    expect(text).toMatch(/2018[–-]\d{4}/) // – is en-dash
+  })
+
+  it('links to the author profile', () => {
+    render(<Footer />)
+    const link = screen.getByRole('link', { name: /paulo raoni/i })
+    expect(link).toHaveAttribute('href', 'https://github.com/paulo-raoni')
+  })
+})

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,11 +1,18 @@
-import { Trans } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import styles from './Footer.module.css'
 
-const Footer = () => (
-  <footer className={styles.wrapper}>
-    <Trans i18nKey="footer.copyright">Copyright © 2018 by</Trans>{' '}
-    <a href="https://github.com/paulo-raoni">Paulo Raoni</a>
-  </footer>
-)
+const START_YEAR = 2018
+
+const Footer = () => {
+  const { t } = useTranslation()
+  const currentYear = new Date().getFullYear()
+
+  return (
+    <footer className={styles.wrapper}>
+      {t('footer.copyright', { startYear: START_YEAR, currentYear })}{' '}
+      <a href="https://github.com/paulo-raoni">Paulo Raoni</a>
+    </footer>
+  )
+}
 
 export default Footer

--- a/src/components/ThemeSwitcher.module.css
+++ b/src/components/ThemeSwitcher.module.css
@@ -4,6 +4,7 @@
 }
 
 .trigger {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -23,6 +24,17 @@
 .trigger:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
+}
+
+.autoIndicator {
+  position: absolute;
+  bottom: 3px;
+  right: 3px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 1px solid var(--bg-surface);
 }
 
 .panel {

--- a/src/components/ThemeSwitcher.test.tsx
+++ b/src/components/ThemeSwitcher.test.tsx
@@ -1,27 +1,70 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { THEME_STORAGE_KEY } from '../theme/storage'
 import ThemeSwitcher from './ThemeSwitcher'
+
+const setMatchMedia = (matchesDark: boolean) => {
+  vi.stubGlobal('matchMedia', (() => ({
+    matches: matchesDark,
+    media: '(prefers-color-scheme: dark)',
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  })) as unknown as typeof window.matchMedia)
+}
 
 describe('ThemeSwitcher', () => {
   beforeEach(() => {
     window.localStorage.clear()
     document.documentElement.removeAttribute('data-theme')
+    setMatchMedia(false) // OS light by default
   })
 
   afterEach(() => {
     document.documentElement.removeAttribute('data-theme')
+    vi.unstubAllGlobals()
   })
 
-  it('renders collapsed and shows the trigger', () => {
+  it('trigger reflects the resolved theme, not the choice (system + OS light → Sun)', () => {
     render(<ThemeSwitcher />)
     const trigger = screen.getByRole('button', { name: /tema/i })
-    expect(trigger).toBeInTheDocument()
-    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(trigger.querySelector('[data-icon="sun"]')).toBeInTheDocument()
+    expect(trigger.querySelector('[data-icon="moon"]')).not.toBeInTheDocument()
   })
 
-  it('opening reveals the three choices with the active one marked', async () => {
+  it('shows the auto indicator dot when choice is system', () => {
+    render(<ThemeSwitcher />)
+    // default choice is system
+    const trigger = screen.getByRole('button', { name: /tema/i })
+    expect(trigger).toHaveAttribute('data-choice', 'system')
+    // indicator is a span with aria-hidden inside the trigger
+    expect(trigger.querySelector('[aria-hidden="true"]:not(svg)')).toBeInTheDocument()
+  })
+
+  it('selecting light hides the auto indicator and keeps a Sun trigger', async () => {
+    const user = userEvent.setup()
+    render(<ThemeSwitcher />)
+    await user.click(screen.getByRole('button', { name: /tema/i }))
+    await user.click(screen.getByRole('button', { name: 'Claro' }))
+
+    const trigger = screen.getByRole('button', { name: /tema/i })
+    expect(trigger).toHaveAttribute('data-choice', 'light')
+    expect(trigger.querySelector('[data-icon="sun"]')).toBeInTheDocument()
+    expect(trigger.querySelector('[aria-hidden="true"]:not(svg)')).not.toBeInTheDocument()
+  })
+
+  it('selecting dark swaps the trigger to a Moon icon', async () => {
+    const user = userEvent.setup()
+    render(<ThemeSwitcher />)
+    await user.click(screen.getByRole('button', { name: /tema/i }))
+    await user.click(screen.getByRole('button', { name: 'Escuro' }))
+
+    const trigger = screen.getByRole('button', { name: /tema/i })
+    expect(trigger.querySelector('[data-icon="moon"]')).toBeInTheDocument()
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
+  })
+
+  it('opening reveals all three options with the active one marked', async () => {
     const user = userEvent.setup()
     render(<ThemeSwitcher />)
     await user.click(screen.getByRole('button', { name: /tema/i }))
@@ -29,17 +72,6 @@ describe('ThemeSwitcher', () => {
     expect(screen.getByRole('button', { name: 'Claro' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Escuro' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Sistema' })).toHaveAttribute('aria-current', 'true')
-  })
-
-  it('selecting dark applies data-theme=dark and persists', async () => {
-    const user = userEvent.setup()
-    render(<ThemeSwitcher />)
-    await user.click(screen.getByRole('button', { name: /tema/i }))
-    await user.click(screen.getByRole('button', { name: 'Escuro' }))
-
-    expect(document.documentElement.dataset.theme).toBe('dark')
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
-    expect(screen.getByRole('button', { name: /tema/i })).toHaveAttribute('aria-expanded', 'false')
   })
 
   it('Escape closes the panel and restores focus to the trigger', async () => {

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -16,6 +16,7 @@ const SunIcon = (props: SVGProps<SVGSVGElement>) => (
     strokeLinejoin="round"
     aria-hidden="true"
     focusable="false"
+    data-icon="sun"
     {...props}
   >
     <circle cx="12" cy="12" r="4" />
@@ -35,6 +36,7 @@ const MoonIcon = (props: SVGProps<SVGSVGElement>) => (
     strokeLinejoin="round"
     aria-hidden="true"
     focusable="false"
+    data-icon="moon"
     {...props}
   >
     <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
@@ -53,6 +55,7 @@ const MonitorIcon = (props: SVGProps<SVGSVGElement>) => (
     strokeLinejoin="round"
     aria-hidden="true"
     focusable="false"
+    data-icon="monitor"
     {...props}
   >
     <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
@@ -61,7 +64,7 @@ const MonitorIcon = (props: SVGProps<SVGSVGElement>) => (
   </svg>
 )
 
-const ICONS: Record<ThemeChoice, (p: SVGProps<SVGSVGElement>) => JSX.Element> = {
+const OPTION_ICONS: Record<ThemeChoice, (p: SVGProps<SVGSVGElement>) => JSX.Element> = {
   light: SunIcon,
   dark: MoonIcon,
   system: MonitorIcon,
@@ -69,7 +72,7 @@ const ICONS: Record<ThemeChoice, (p: SVGProps<SVGSVGElement>) => JSX.Element> = 
 
 const ThemeSwitcher = () => {
   const { t } = useTranslation()
-  const { choice, setChoice } = useTheme()
+  const { choice, resolved, setChoice } = useTheme()
   const [open, setOpen] = useState(false)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
@@ -106,7 +109,7 @@ const ThemeSwitcher = () => {
     triggerRef.current?.focus()
   }
 
-  const TriggerIcon = ICONS[choice]
+  const TriggerIcon = resolved === 'dark' ? MoonIcon : SunIcon
 
   return (
     <div className={styles.wrapper}>
@@ -114,6 +117,7 @@ const ThemeSwitcher = () => {
         ref={triggerRef}
         type="button"
         className={styles.trigger}
+        data-choice={choice}
         aria-label={t('theme.label')}
         aria-haspopup="true"
         aria-expanded={open}
@@ -121,6 +125,7 @@ const ThemeSwitcher = () => {
         onClick={() => setOpen((prev) => !prev)}
       >
         <TriggerIcon />
+        {choice === 'system' && <span className={styles.autoIndicator} aria-hidden="true" />}
       </button>
       {open && (
         <div
@@ -131,7 +136,7 @@ const ThemeSwitcher = () => {
           aria-label={t('theme.label')}
         >
           {THEME_CHOICES.map((value) => {
-            const Icon = ICONS[value]
+            const Icon = OPTION_ICONS[value]
             const isActive = value === choice
             return (
               <button

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -11,7 +11,7 @@
     "deleteAria": "Delete todo: {{conteudo}}"
   },
   "footer": {
-    "copyright": "Copyright © 2018 by"
+    "copyright": "Copyright © {{startYear}}–{{currentYear}} by"
   },
   "lang": {
     "label": "Language",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -11,7 +11,7 @@
     "deleteAria": "Excluir tarefa: {{conteudo}}"
   },
   "footer": {
-    "copyright": "Copyright © 2018 by"
+    "copyright": "Copyright © {{startYear}}–{{currentYear}} por"
   },
   "lang": {
     "label": "Idioma",


### PR DESCRIPTION
Phase 8 of 9 in the agentic modernization plan. Phase 9 (English-only refactor) is deferred per the plan.

## What changed

### Theme switcher refinement
- Trigger now reflects the **resolved** theme (Sun or Moon), never Monitor.
- A small accent-colored dot in the corner of the trigger indicates `choice === 'system'`. The dropdown panel still lists all three explicit choices with the active one marked via `aria-current`.
- Switcher tests rewritten to assert resolved-driven trigger plus auto-indicator behavior.

### Footer
- Copyright text is now a dynamic range `Copyright © 2018–{currentYear} by …` via i18n interpolation. The author link remains plain HTML outside the translated string.
- New `Footer.test.tsx` covers the year range and author link.

### Manifest + favicons
- `public/manifest.json`: relative `start_url`/`scope` (`./`), description, `lang: pt-BR`, light-default theme/background colors, SVG icon entry added alongside the legacy ICO.
- New `public/favicon.svg`: minimal checklist icon with `prefers-color-scheme`-aware fill (#2e7d32 light / #66bb6a dark).
- `index.html`: `<link rel="icon" type="image/svg+xml" …>` + ICO fallback.

### Meta tags
- Open Graph + Twitter card (summary type) added to `index.html`. Title, description, URL, locale alternates.
- The dynamic `<meta name="theme-color">` updater from Phase 7 keeps working unchanged.

### README
- Full rewrite. Badges, live demo, features, tech stack, scripts, project structure, 8-phase modernization journey, MIT license with the new copyright range.

## Verification

Local (Codespace):

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm test` ✅ (56 passing — Footer +2, ThemeSwitcher count unchanged)
- `npm run build` ✅
- `npm run test:e2e` ✅ (21 passing, no e2e changes)

Lighthouse on the production preview build (`npm run preview`) is a manual local step; CI does not gate on it.

## Out of scope

- 192/512 raster PNG icons for full PWA installability — would require image generation.
- OG preview image — same reason.
- Lighthouse CI workflow — manual validation is sufficient for a portfolio with low churn.
- Screenshots in README — replaced by a prominent live-demo link.