### PR TITLE
feat(ui): placeholder + Add button from community feedback

### DIFF
--- a/src/components/AddTarefa.module.css
+++ b/src/components/AddTarefa.module.css
@@ -10,8 +10,15 @@
   color: var(--text);
 }
 
+.row {
+  display: flex;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
 .input {
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   padding: 0.6rem 0.75rem;
   font-size: 1rem;
   border: 1px solid var(--border);
@@ -23,7 +30,41 @@
   transition: border-color 0.2s;
 }
 
+.input::placeholder {
+  color: var(--text-empty);
+  opacity: 1;
+}
+
 .input:focus {
   border-bottom-color: var(--accent);
   box-shadow: 0 1px 0 0 var(--accent);
+}
+
+.button {
+  font: inherit;
+  padding: 0 1.25rem;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  background: var(--accent);
+  color: var(--text-inverse);
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    border-color 0.2s,
+    color 0.2s;
+}
+
+.button:hover:not(:disabled) {
+  background: transparent;
+  color: var(--accent);
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }

--- a/src/components/AddTarefa.test.tsx
+++ b/src/components/AddTarefa.test.tsx
@@ -11,7 +11,46 @@ describe('AddTarefa', () => {
     expect(input.tagName).toBe('INPUT')
   })
 
-  it('calls onAdd with trimmed content when submitting via Enter', async () => {
+  it('shows a translated placeholder', () => {
+    render(<AddTarefa onAdd={() => {}} />)
+    const input = screen.getByLabelText(/escreva abaixo uma tarefa/i)
+    expect(input).toHaveAttribute('placeholder', 'Ex.: Comprar leite')
+  })
+
+  it('renders an Add submit button that is disabled while the input is empty', () => {
+    render(<AddTarefa onAdd={() => {}} />)
+    const button = screen.getByRole('button', { name: /adicionar/i })
+    expect(button).toHaveAttribute('type', 'submit')
+    expect(button).toBeDisabled()
+  })
+
+  it('enables the Add button once the input has non-whitespace content', async () => {
+    const user = userEvent.setup()
+    render(<AddTarefa onAdd={() => {}} />)
+    const button = screen.getByRole('button', { name: /adicionar/i })
+    const input = screen.getByLabelText(/escreva abaixo uma tarefa/i)
+
+    await user.type(input, '   ')
+    expect(button).toBeDisabled()
+
+    await user.type(input, 'hello')
+    expect(button).toBeEnabled()
+  })
+
+  it('calls onAdd with trimmed content when the button is clicked', async () => {
+    const user = userEvent.setup()
+    const onAdd = vi.fn()
+    render(<AddTarefa onAdd={onAdd} />)
+    const input = screen.getByLabelText(/escreva abaixo uma tarefa/i)
+
+    await user.type(input, '  buy milk  ')
+    await user.click(screen.getByRole('button', { name: /adicionar/i }))
+
+    expect(onAdd).toHaveBeenCalledOnce()
+    expect(onAdd).toHaveBeenCalledWith('buy milk')
+  })
+
+  it('still calls onAdd when submitting via Enter', async () => {
     const user = userEvent.setup()
     const onAdd = vi.fn()
     render(<AddTarefa onAdd={onAdd} />)
@@ -24,7 +63,7 @@ describe('AddTarefa', () => {
     expect(onAdd).toHaveBeenCalledWith('hello')
   })
 
-  it('does not call onAdd when input is empty or whitespace-only', async () => {
+  it('does not call onAdd when input is empty or whitespace', async () => {
     const user = userEvent.setup()
     const onAdd = vi.fn()
     render(<AddTarefa onAdd={onAdd} />)
@@ -36,13 +75,13 @@ describe('AddTarefa', () => {
     expect(onAdd).not.toHaveBeenCalled()
   })
 
-  it('clears the input after a successful add', async () => {
+  it('clears the input after a successful add via the button', async () => {
     const user = userEvent.setup()
     render(<AddTarefa onAdd={() => {}} />)
     const input = screen.getByLabelText(/escreva abaixo uma tarefa/i) as HTMLInputElement
 
     await user.type(input, 'task')
-    await user.keyboard('{Enter}')
+    await user.click(screen.getByRole('button', { name: /adicionar/i }))
 
     expect(input.value).toBe('')
   })

--- a/src/components/AddTarefa.tsx
+++ b/src/components/AddTarefa.tsx
@@ -27,18 +27,26 @@ const AddTarefa = ({ onAdd }: AddTarefaProps) => {
     setConteudo('')
   }
 
+  const isDisabled = conteudo.trim().length === 0
+
   return (
     <form className={styles.wrapper} onSubmit={handleSubmit}>
       <label className={styles.label} htmlFor={INPUT_ID}>
         {t('addTarefa.label')}
       </label>
-      <input
-        id={INPUT_ID}
-        className={styles.input}
-        type="text"
-        onChange={handleChange}
-        value={conteudo}
-      />
+      <div className={styles.row}>
+        <input
+          id={INPUT_ID}
+          className={styles.input}
+          type="text"
+          placeholder={t('addTarefa.placeholder')}
+          onChange={handleChange}
+          value={conteudo}
+        />
+        <button type="submit" className={styles.button} disabled={isDisabled}>
+          {t('addTarefa.button')}
+        </button>
+      </div>
     </form>
   )
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3,7 +3,9 @@
     "title": "Todo List App"
   },
   "addTarefa": {
-    "label": "Type a todo below and press enter to add:"
+    "label": "Type a todo below and press enter to add:",
+    "placeholder": "e.g., Buy milk",
+    "button": "Add"
   },
   "tarefas": {
     "empty": "No todos yet.",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -3,7 +3,9 @@
     "title": "Lista de Tarefas App"
   },
   "addTarefa": {
-    "label": "Escreva abaixo uma tarefa e digite enter para adicionar:"
+    "label": "Escreva abaixo uma tarefa e digite enter para adicionar:",
+    "placeholder": "Ex.: Comprar leite",
+    "button": "Adicionar"
   },
   "tarefas": {
     "empty": "Não há tarefas ainda.",

--- a/tests/e2e/i18n.spec.ts
+++ b/tests/e2e/i18n.spec.ts
@@ -35,6 +35,11 @@ test('switching to EN updates UI strings live and closes the panel', async ({ pa
 
   await expect(page.getByRole('heading', { level: 1 })).toHaveText('Todo List App')
   await expect(page.getByLabel(/type a todo below/i)).toBeVisible()
+  await expect(page.getByLabel(/type a todo below/i)).toHaveAttribute(
+    'placeholder',
+    'e.g., Buy milk',
+  )
+  await expect(page.getByRole('button', { name: 'Add' })).toBeVisible()
   await expect(page.getByRole('button', { name: 'Delete todo: Tarefa exemplo 1' })).toBeVisible()
   await expect(page.getByRole('button', { name: /language/i })).toHaveAttribute(
     'aria-expanded',

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -22,6 +22,21 @@ test('adds a tarefa via Enter and clears the input', async ({ page }) => {
   await expect(input).toHaveValue('')
 })
 
+test('adds a tarefa via the Add button and clears the input', async ({ page }) => {
+  const input = page.getByLabel(/escreva abaixo uma tarefa/i)
+  const button = page.getByRole('button', { name: /adicionar/i })
+
+  await expect(button).toBeDisabled()
+  await input.fill('Button-added task')
+  await expect(button).toBeEnabled()
+  await button.click()
+
+  await expect(
+    page.getByRole('button', { name: 'Excluir tarefa: Button-added task' }),
+  ).toBeVisible()
+  await expect(input).toHaveValue('')
+})
+
 test('clicking a tarefa removes it after the animation delay', async ({ page }) => {
   const target = page.getByRole('button', { name: 'Excluir tarefa: Tarefa exemplo 1' })
   await target.click()


### PR DESCRIPTION
Closes the two oldest open issues, [#1](https://github.com/paulo-raoni/lista-de-tarefas/issues/1) ("Botão adicionar - Melhoria") and [#2](https://github.com/paulo-raoni/lista-de-tarefas/issues/2) ("UI/UX - Melhoria"), both opened by @an-jorge in 2022. The modernization landed first; this small PR catches up on the community feedback that was waiting.

## What changed

- **Explicit "Adicionar" / "Add" button** (`type="submit"`) inside the form, next to the input. Disabled when the trimmed input is empty so clicking it never does nothing surprisingly.
- **Translated placeholder** on the input (`Ex.: Comprar leite` / `e.g., Buy milk`).
- **Layout shift:** label stays on top (a11y); input + button now share a flex row below it.
- **Both new strings (button + placeholder)** live in the i18n catalog and switch with the language toggle.
- **No change to Enter behavior** — Enter still submits via the form's default. The button is an additional affordance, not a replacement.
- **Disabled state** uses opacity 0.5 + cursor:not-allowed. Works in both themes via existing CSS variables (`--accent`, `--text-inverse`).

## Verification

Local (Codespace):

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm test` ✅ (60 passing, AddTarefa goes 4 → 8)
- `npm run build` ✅
- `npm run test:e2e` ✅ (22 passing, smoke +1 button-path scenario, i18n spec asserts button + placeholder translate)

Fixes #1
Fixes #2