### PR TITLE
chore: add LICENSE file at repo root

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-2026 Paulo Raoni Costa Bezerra
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -88,12 +88,4 @@ A future Phase 9 will rename Portuguese identifiers throughout the codebase (fil
 
 ## License
 
-MIT.
-
-Copyright © 2018–2026 Paulo Raoni Costa Bezerra.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+[MIT](./LICENSE) — Copyright © 2018–2026 Paulo Raoni Costa Bezerra.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "lista-de-tarefas",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "i18next": "^26.1.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "lista-de-tarefas",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "engines": {
     "node": ">=20.19 <21"


### PR DESCRIPTION
Small follow-up to the Phase 8 polish: add a standalone `LICENSE` file so GitHub auto-detects the project as MIT in the repo About sidebar and via the licenses API.

## What changed

- New `LICENSE` at the repo root, standard MIT text, 2018–2026 copyright range matching the dynamic footer.
- README license section shortened from the full boilerplate to `[MIT](./LICENSE) — Copyright © 2018–2026 Paulo Raoni Costa Bezerra.`. No content lost; the full text lives in `LICENSE`.

## Verification

- All gates green locally and on CI.
- After merge, `gh api repos/paulo-raoni/lista-de-tarefas --jq '.license.spdx_id'` should return `"MIT"` and the GitHub UI About sidebar should show the license badge.